### PR TITLE
But onExit under a mask.

### DIFF
--- a/Control/Monad/Trans/Region/Internal.hs
+++ b/Control/Monad/Trans/Region/Internal.hs
@@ -195,7 +195,7 @@ finalizer 1
 onExit :: (region ~ RegionT s parent, MonadBase IO parent)
        => Finalizer
        -> region (FinalizerHandle region)
-onExit finalizer = RegionT $ ReaderT $ \hsIORef -> liftBase $ do
+onExit finalizer = RegionT $ ReaderT $ \hsIORef -> liftBase $ mask_ $ do
                      refCntIORef <- newIORef 1
                      let h = RefCountedFinalizer finalizer refCntIORef
                      modifyIORef hsIORef (h:)


### PR DESCRIPTION
Previously code had potential race condition, because asynchronous
event may arrive when onExit function is in the middle on a register
then it will never be called.

This means that it should either be documented (and user will have
to provided required protection on his own), or function should be
implemented in a safe way. The former approach was choosen.

---

I'm not sure if this way is the most sane one and maybe we just need
to add few more docs.
