### PR TITLE
Remove unused language extensions, update comment

### DIFF
--- a/Control/Monad/Trans/Region/Internal.hs
+++ b/Control/Monad/Trans/Region/Internal.hs
@@ -7,9 +7,7 @@
            , UndecidableInstances       -- For the AncestorRegion instances.
            , FlexibleInstances          -- ,,          ,,          ,,
            , OverlappingInstances       -- ,,          ,,          ,,
-           , TypeFamilies               -- For the RegionBaseControl class.
-           , FunctionalDependencies     -- ,,          ,,          ,,
-           , FlexibleContexts           -- For MonadBase.
+           , TypeFamilies               -- For the RegionIOControl class.
   #-}
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
FunctionalDependencies and FlexibleContexts are no longer needed in Internal.hs. Also update the comment on TypeFamilies to reflect the change from RegionBaseControl to RegionIOControl.
